### PR TITLE
added redirect logic for authenticated folks

### DIFF
--- a/src/app/components/AuthButtons.tsx
+++ b/src/app/components/AuthButtons.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { SignInButton, SignUpButton, SignedOut } from '@clerk/nextjs';
+
+export default function AuthButtons() {
+    return(
+         <SignedOut>
+          <SignInButton mode="modal">
+            <button className="bg-gray-200 text-gray-800 hover:bg-gray-300 rounded-full font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-6 cursor-pointer">
+              Sign In
+            </button>
+          </SignInButton>
+
+          <SignUpButton mode="modal">
+            <button className="bg-[#6c47ff] text-white hover:bg-[#5a38e0] rounded-full font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-6 cursor-pointer">
+              Sign Up
+            </button>
+          </SignUpButton>
+        </SignedOut>
+    )
+}

--- a/src/app/components/GuardedRoutes.tsx
+++ b/src/app/components/GuardedRoutes.tsx
@@ -1,0 +1,32 @@
+// This is a server component that appropriatelyredirects users depending if they are authenticated or not authenticated
+
+import { ReactNode } from "react";
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+
+interface GuardedRoutesProps {
+    whenSignedInRedirectTo?: string;
+    whenSignedOutRedirectTo?: string;
+    children?: ReactNode;
+  }
+
+export default async function GuardedRoutes({
+  whenSignedInRedirectTo,
+  whenSignedOutRedirectTo,
+  children,
+}: GuardedRoutesProps) {
+  const { userId } = await auth();
+
+  // Redirect if signed in and a redirect path is provided
+  if (userId && whenSignedInRedirectTo) {
+    redirect(whenSignedInRedirectTo)
+  }
+
+  // Redirect if signed out and a redirect path is provided
+  if (!userId && whenSignedOutRedirectTo) {
+    redirect(whenSignedOutRedirectTo)
+  }
+
+  // otherwise render children (if any)
+  return <>{children}</>
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,11 @@
-'use client';
+import GuardedRoutes from './components/GuardedRoutes';
+import AuthButtons from './components/AuthButtons';
 
-import { SignInButton, SignUpButton, SignedOut } from '@clerk/nextjs';
+
 export default function Home() {
   return (
+    <>
+    <GuardedRoutes whenSignedInRedirectTo="/dashboard">
     <main className="flex flex-col items-center justify-center min-h-screen px-6 py-16 bg-white text-center"> 
      <h1 className="text-5xl md:text-6xl font-semibold leading-snug gradient">
         Welcome to Pulse Check
@@ -13,21 +16,11 @@ export default function Home() {
       </p>
 
       <div className="mt-8 flex gap-4">
-        <SignedOut>
-          <SignInButton mode="modal">
-            <button className="bg-gray-200 text-gray-800 hover:bg-gray-300 rounded-full font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-6 cursor-pointer">
-              Sign In
-            </button>
-          </SignInButton>
-
-          <SignUpButton mode="modal">
-            <button className="bg-[#6c47ff] text-white hover:bg-[#5a38e0] rounded-full font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-6 cursor-pointer">
-              Sign Up
-            </button>
-          </SignUpButton>
-        </SignedOut>
+        <AuthButtons />
       </div>
  
     </main>
+    </GuardedRoutes>
+    </>
   );
 }


### PR DESCRIPTION
- Built a modular and scalable GuardedRoute server component that accepts `whenSignedInRedirectTo` and `whenSignedOutRedirectTo` props uses auth() from Clerk and supports conditional redirecting or just rendering children. 

- Moved client side`SignedOut` and `SignedInButton` to their own client component `AuthButtons` and imported that component into the server side page.tsx (Homepage). 